### PR TITLE
Fixup implicit-function-declaration warnings

### DIFF
--- a/src/pull_by_re.c
+++ b/src/pull_by_re.c
@@ -11,6 +11,7 @@
 #include "file_read.h"
 #include "global.h"
 #include "size_filter.h"
+#include "search_header.h"
 
 
 __KS_GETC(gzread, BUFFER_SIZE)

--- a/src/pull_by_re.h
+++ b/src/pull_by_re.h
@@ -1,5 +1,5 @@
-#ifndef PULL_BY_SIZE_H
-#define PULL_BY_SIZE_H
+#ifndef PULL_BY_RE_H
+#define PULL_BY_RE_H
 
 int pull_by_re(char *input_file, char *aStrRegex, int min, int max, int length, int exclude, int convert, int just_count);
 


### PR DESCRIPTION
Fixup for:

> gcc -DHAVE_CONFIG_H -I.   -Wdate-time -D_FORTIFY_SOURCE=2  -g -O2 -Werror=implicit-function-declaration -ffile-prefix-map=/<<PKGBUILDDIR>>=. -fstack-protector-strong -fstack-clash-protection -Wformat -Werror=format-security -fcf-protection -fcommon -c -o pull_by_size.o pull_by_size.c
> pull_by_re.c: In function ‘pull_by_re’:
> pull_by_re.c:76:29: error: implicit declaration of function ‘search_header’ [-Werror=implicit-function-declaration]
>    76 |                         if (search_header(re, seq->name.s) || search_header(re, seq->comment.s))
>       |                             ^~~~~~~~~~~~~
> gcc -DHAVE_CONFIG_H -I.   -Wdate-time -D_FORTIFY_SOURCE=2  -g -O2 -Werror=implicit-function-declaration -ffile-prefix-map=/<<PKGBUILDDIR>>=. -fstack-protector-strong -fstack-clash-protection -Wformat -Werror=format-security -fcf-protection -fcommon -c -o pullseq.o pullseq.c
> gcc -DHAVE_CONFIG_H -I.   -Wdate-time -D_FORTIFY_SOURCE=2  -g -O2 -Werror=implicit-function-declaration -ffile-prefix-map=/<<PKGBUILDDIR>>=. -fstack-protector-strong -fstack-clash-protection -Wformat -Werror=format-security -fcf-protection -fcommon -c -o cmpseq.o cmpseq.c
> pullseq.c: In function ‘main’:
> pullseq.c:275:25: error: implicit declaration of function ‘pull_by_re’; did you mean ‘pull_by_size’? [-Werror=implicit-function-declaration]
>   275 |                 count = pull_by_re(in, aStrRegex, min, max, length, exclude, convert, just_count);
>       |                         ^~~~~~~~~~
>       |                         pull_by_size
> gcc -DHAVE_CONFIG_H -I.   -Wdate-time -D_FORTIFY_SOURCE=2  -g -O2 -Werror=implicit-function-declaration -ffile-prefix-map=/<<PKGBUILDDIR>>=. -fstack-protector-strong -fstack-clash-protection -Wformat -Werror=format-security -fcf-protection -fcommon -c -o seqdiff.o seqdiff.c
> gcc -DHAVE_CONFIG_H -I.   -Wdate-time -D_FORTIFY_SOURCE=2  -g -O2 -Werror=implicit-function-declaration -ffile-prefix-map=/<<PKGBUILDDIR>>=. -fstack-protector-strong -fstack-clash-protection -Wformat -Werror=format-security -fcf-protection -fcommon -c -o seqdiff_results.o seqdiff_results.c
> cc1: some warnings being treated as errors
> make[3]: *** [Makefile:413: pull_by_re.o] Error 1

/cc: @bcthomas 